### PR TITLE
fix: Fix interval calculation and add rest time metric

### DIFF
--- a/src/components/Charts/ChartControls.tsx
+++ b/src/components/Charts/ChartControls.tsx
@@ -1,10 +1,6 @@
-import { ChartDisplayMode } from '../../services/storage/localStorage';
-
 interface ChartControlsProps {
   timeRange: number;
   onTimeRangeChange: (hours: number) => void;
-  displayMode: ChartDisplayMode;
-  onDisplayModeChange: (mode: ChartDisplayMode) => void;
 }
 
 const timeRanges = [
@@ -14,57 +10,26 @@ const timeRanges = [
   { label: 'All', hours: 0 },
 ];
 
-const displayModes: { label: string; mode: ChartDisplayMode }[] = [
-  { label: 'Duration', mode: 'duration' },
-  { label: 'Interval', mode: 'interval' },
-  { label: 'Both', mode: 'both' },
-];
-
-const ChartControls = ({ timeRange, onTimeRangeChange, displayMode, onDisplayModeChange }: ChartControlsProps) => {
+const ChartControls = ({ timeRange, onTimeRangeChange }: ChartControlsProps) => {
   return (
-    <div className="space-y-4">
-      {/* Display Mode Controls */}
-      <div>
-        <label className="block text-sm font-medium mb-2">Chart View</label>
-        <div className="flex gap-2 flex-wrap">
-          {displayModes.map((mode) => (
-            <button
-              key={mode.mode}
-              onClick={() => onDisplayModeChange(mode.mode)}
-              className={`
-                px-4 py-2 rounded-lg font-medium transition-colors
-                ${displayMode === mode.mode
-                  ? 'bg-primary text-white'
-                  : 'bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600'
-                }
-              `}
-            >
-              {mode.label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Time Range Controls */}
-      <div>
-        <label className="block text-sm font-medium mb-2">Time Range</label>
-        <div className="flex gap-2 flex-wrap">
-          {timeRanges.map((range) => (
-            <button
-              key={range.hours}
-              onClick={() => onTimeRangeChange(range.hours)}
-              className={`
-                px-4 py-2 rounded-lg font-medium transition-colors
-                ${timeRange === range.hours
-                  ? 'bg-primary text-white'
-                  : 'bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600'
-                }
-              `}
-            >
-              {range.label}
-            </button>
-          ))}
-        </div>
+    <div>
+      <label className="block text-sm font-medium mb-2">Time Range</label>
+      <div className="flex gap-2 flex-wrap">
+        {timeRanges.map((range) => (
+          <button
+            key={range.hours}
+            onClick={() => onTimeRangeChange(range.hours)}
+            className={`
+              px-4 py-2 rounded-lg font-medium transition-colors
+              ${timeRange === range.hours
+                ? 'bg-primary text-white'
+                : 'bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600'
+              }
+            `}
+          >
+            {range.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/Charts/ContractionChart.tsx
+++ b/src/components/Charts/ContractionChart.tsx
@@ -5,14 +5,12 @@ import { useTheme } from '../../contexts/ThemeContext';
 import { getContractionsInTimeRange } from '../../utils/calculations';
 import { formatTime } from '../../utils/dateTime';
 import ChartControls from './ChartControls';
-import { ChartDisplayMode, getChartDisplayMode, setChartDisplayMode } from '../../services/storage/localStorage';
 
 const ContractionChart = () => {
   const { state } = useContractions();
   const { theme } = useTheme();
   const { contractions } = state;
-  const [timeRange, setTimeRange] = useState(6); // Default to 6 hours
-  const [displayMode, setDisplayMode] = useState<ChartDisplayMode>(getChartDisplayMode());
+  const [timeRange, setTimeRange] = useState(0); // Default to All
 
   const chartData = useMemo(() => {
     const filteredContractions = timeRange > 0
@@ -26,201 +24,37 @@ const ContractionChart = () => {
     const reversed = [...completed].reverse();
 
     return reversed.map((contraction, index) => {
-      // Calculate interval from previous contraction
-      let interval = 0;
+      let interval = null;
+      let restTime = null;
+
       if (index > 0) {
-        interval = Math.floor((contraction.startTime - reversed[index - 1].startTime) / 1000 / 60); // minutes
+        const prev = reversed[index - 1];
+        interval = Math.floor((contraction.startTime - prev.startTime) / 1000 / 60); // minutes
+        if (prev.endTime) {
+          restTime = Math.floor((contraction.startTime - prev.endTime) / 1000 / 60); // minutes
+        }
       }
 
       return {
         time: formatTime(contraction.startTime),
         timestamp: contraction.startTime,
         duration: contraction.duration,
-        interval: interval > 0 ? interval : null,
+        interval: interval !== null && interval > 0 ? interval : null,
+        restTime: restTime !== null && restTime > 0 ? restTime : null,
       };
     });
   }, [contractions, timeRange]);
 
   const isDark = theme === 'dark';
 
-  const handleModeChange = (mode: ChartDisplayMode) => {
-    setDisplayMode(mode);
-    setChartDisplayMode(mode);
+  const gridColor = isDark ? '#334155' : '#cbd5e1';
+  const axisColor = isDark ? '#94a3b8' : '#64748b';
+  const tooltipStyle = {
+    backgroundColor: isDark ? '#1e293b' : '#ffffff',
+    border: `1px solid ${isDark ? '#334155' : '#e2e8f0'}`,
+    borderRadius: '8px',
+    color: isDark ? '#f1f5f9' : '#0f172a',
   };
-
-  const renderDurationChart = () => (
-    <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
-      <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={chartData}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            stroke={isDark ? '#334155' : '#cbd5e1'}
-          />
-          <XAxis
-            dataKey="time"
-            stroke={isDark ? '#94a3b8' : '#64748b'}
-            tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-          />
-          <YAxis
-            label={{ value: 'Duration (seconds)', angle: -90, position: 'insideLeft', fill: isDark ? '#94a3b8' : '#64748b' }}
-            stroke={isDark ? '#94a3b8' : '#64748b'}
-            tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: isDark ? '#1e293b' : '#ffffff',
-              border: `1px solid ${isDark ? '#334155' : '#e2e8f0'}`,
-              borderRadius: '8px',
-              color: isDark ? '#f1f5f9' : '#0f172a',
-            }}
-            formatter={(value: any) => [`${value}s`, 'Duration']}
-          />
-          <Legend wrapperStyle={{ color: isDark ? '#94a3b8' : '#64748b' }} />
-          <Line
-            type="monotone"
-            dataKey="duration"
-            stroke="#3B82F6"
-            strokeWidth={2}
-            dot={{ fill: '#3B82F6', r: 4 }}
-            name="Duration (seconds)"
-          />
-        </LineChart>
-      </ResponsiveContainer>
-      <div className="mt-4 flex items-center gap-2 text-sm">
-        <div className="w-4 h-4 bg-primary rounded"></div>
-        <span className="text-slate-600 dark:text-slate-400">Duration (seconds)</span>
-      </div>
-    </div>
-  );
-
-  const renderIntervalChart = () => (
-    <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
-      <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={chartData}>
-          <CartesianGrid
-            strokeDasharray="3 3"
-            stroke={isDark ? '#334155' : '#cbd5e1'}
-          />
-          <XAxis
-            dataKey="time"
-            stroke={isDark ? '#94a3b8' : '#64748b'}
-            tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-          />
-          <YAxis
-            label={{ value: 'Interval (minutes)', angle: -90, position: 'insideLeft', fill: isDark ? '#94a3b8' : '#64748b' }}
-            stroke={isDark ? '#94a3b8' : '#64748b'}
-            tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: isDark ? '#1e293b' : '#ffffff',
-              border: `1px solid ${isDark ? '#334155' : '#e2e8f0'}`,
-              borderRadius: '8px',
-              color: isDark ? '#f1f5f9' : '#0f172a',
-            }}
-            formatter={(value: any) => [`${value}m`, 'Interval']}
-          />
-          <Legend wrapperStyle={{ color: isDark ? '#94a3b8' : '#64748b' }} />
-          <Line
-            type="monotone"
-            dataKey="interval"
-            stroke="#10B981"
-            strokeWidth={2}
-            dot={{ fill: '#10B981', r: 4 }}
-            name="Interval (minutes)"
-            connectNulls
-          />
-        </LineChart>
-      </ResponsiveContainer>
-      <div className="mt-4 flex items-center gap-2 text-sm">
-        <div className="w-4 h-4 bg-green-500 rounded"></div>
-        <span className="text-slate-600 dark:text-slate-400">Interval (minutes apart)</span>
-      </div>
-    </div>
-  );
-
-  const renderBothCharts = () => (
-    <div className="space-y-4">
-      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
-        <h3 className="text-lg font-semibold mb-3">Contraction Duration</h3>
-        <ResponsiveContainer width="100%" height={250}>
-          <LineChart data={chartData}>
-            <CartesianGrid
-              strokeDasharray="3 3"
-              stroke={isDark ? '#334155' : '#cbd5e1'}
-            />
-            <XAxis
-              dataKey="time"
-              stroke={isDark ? '#94a3b8' : '#64748b'}
-              tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-            />
-            <YAxis
-              stroke={isDark ? '#94a3b8' : '#64748b'}
-              tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: isDark ? '#1e293b' : '#ffffff',
-                border: `1px solid ${isDark ? '#334155' : '#e2e8f0'}`,
-                borderRadius: '8px',
-                color: isDark ? '#f1f5f9' : '#0f172a',
-              }}
-              formatter={(value: any) => [`${value}s`, 'Duration']}
-            />
-            <Legend wrapperStyle={{ color: isDark ? '#94a3b8' : '#64748b' }} />
-            <Line
-              type="monotone"
-              dataKey="duration"
-              stroke="#3B82F6"
-              strokeWidth={2}
-              dot={{ fill: '#3B82F6', r: 4 }}
-              name="Duration (seconds)"
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-
-      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
-        <h3 className="text-lg font-semibold mb-3">Time Between Contractions</h3>
-        <ResponsiveContainer width="100%" height={250}>
-          <LineChart data={chartData}>
-            <CartesianGrid
-              strokeDasharray="3 3"
-              stroke={isDark ? '#334155' : '#cbd5e1'}
-            />
-            <XAxis
-              dataKey="time"
-              stroke={isDark ? '#94a3b8' : '#64748b'}
-              tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-            />
-            <YAxis
-              stroke={isDark ? '#94a3b8' : '#64748b'}
-              tick={{ fill: isDark ? '#94a3b8' : '#64748b' }}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: isDark ? '#1e293b' : '#ffffff',
-                border: `1px solid ${isDark ? '#334155' : '#e2e8f0'}`,
-                borderRadius: '8px',
-                color: isDark ? '#f1f5f9' : '#0f172a',
-              }}
-              formatter={(value: any) => [`${value}m`, 'Interval']}
-            />
-            <Legend wrapperStyle={{ color: isDark ? '#94a3b8' : '#64748b' }} />
-            <Line
-              type="monotone"
-              dataKey="interval"
-              stroke="#10B981"
-              strokeWidth={2}
-              dot={{ fill: '#10B981', r: 4 }}
-              name="Interval (minutes)"
-              connectNulls
-            />
-          </LineChart>
-        </ResponsiveContainer>
-      </div>
-    </div>
-  );
 
   if (chartData.length === 0) {
     return (
@@ -239,14 +73,79 @@ const ContractionChart = () => {
         <ChartControls
           timeRange={timeRange}
           onTimeRangeChange={setTimeRange}
-          displayMode={displayMode}
-          onDisplayModeChange={handleModeChange}
         />
       </div>
 
-      {displayMode === 'duration' && renderDurationChart()}
-      {displayMode === 'interval' && renderIntervalChart()}
-      {displayMode === 'both' && renderBothCharts()}
+      {/* Duration Chart */}
+      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
+        <h3 className="text-lg font-semibold">Contraction Duration</h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-3 italic">How long each contraction lasted (seconds)</p>
+        <ResponsiveContainer width="100%" height={250}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+            <XAxis dataKey="time" stroke={axisColor} tick={{ fill: axisColor }} />
+            <YAxis stroke={axisColor} tick={{ fill: axisColor }} />
+            <Tooltip contentStyle={tooltipStyle} formatter={(value: any) => [`${value}s`, 'Duration']} />
+            <Legend wrapperStyle={{ color: axisColor }} />
+            <Line
+              type="monotone"
+              dataKey="duration"
+              stroke="#3B82F6"
+              strokeWidth={2}
+              dot={{ fill: '#3B82F6', r: 4 }}
+              name="Duration (seconds)"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Interval Chart */}
+      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
+        <h3 className="text-lg font-semibold">Time Between Contractions</h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-3 italic">From start of one contraction to start of the next</p>
+        <ResponsiveContainer width="100%" height={250}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+            <XAxis dataKey="time" stroke={axisColor} tick={{ fill: axisColor }} />
+            <YAxis stroke={axisColor} tick={{ fill: axisColor }} />
+            <Tooltip contentStyle={tooltipStyle} formatter={(value: any) => [`${value}m`, 'Interval']} />
+            <Legend wrapperStyle={{ color: axisColor }} />
+            <Line
+              type="monotone"
+              dataKey="interval"
+              stroke="#10B981"
+              strokeWidth={2}
+              dot={{ fill: '#10B981', r: 4 }}
+              name="Interval (minutes)"
+              connectNulls
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Rest Time Chart */}
+      <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg">
+        <h3 className="text-lg font-semibold">Rest Time</h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400 mb-3 italic">Actual break between contractions (end of one to start of next)</p>
+        <ResponsiveContainer width="100%" height={250}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" stroke={gridColor} />
+            <XAxis dataKey="time" stroke={axisColor} tick={{ fill: axisColor }} />
+            <YAxis stroke={axisColor} tick={{ fill: axisColor }} />
+            <Tooltip contentStyle={tooltipStyle} formatter={(value: any) => [`${value}m`, 'Rest']} />
+            <Legend wrapperStyle={{ color: axisColor }} />
+            <Line
+              type="monotone"
+              dataKey="restTime"
+              stroke="#F59E0B"
+              strokeWidth={2}
+              dot={{ fill: '#F59E0B', r: 4 }}
+              name="Rest Time (minutes)"
+              connectNulls
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/src/components/Charts/ContractionChart.tsx
+++ b/src/components/Charts/ContractionChart.tsx
@@ -28,8 +28,8 @@ const ContractionChart = () => {
     return reversed.map((contraction, index) => {
       // Calculate interval from previous contraction
       let interval = 0;
-      if (index > 0 && reversed[index - 1].endTime) {
-        interval = Math.floor((contraction.startTime - reversed[index - 1].endTime!) / 1000 / 60); // minutes
+      if (index > 0) {
+        interval = Math.floor((contraction.startTime - reversed[index - 1].startTime) / 1000 / 60); // minutes
       }
 
       return {

--- a/src/components/Timer/ContractionSummary.tsx
+++ b/src/components/Timer/ContractionSummary.tsx
@@ -1,8 +1,8 @@
 import { motion } from 'framer-motion';
 import { useContractions } from '../../contexts/ContractionContext';
-import { calculateStats } from '../../utils/calculations';
-import { formatTime, formatDurationReadable, formatInterval } from '../../utils/dateTime';
-import { Clock, Activity, TrendingUp } from 'lucide-react';
+import { calculateStats, calculateRestTime } from '../../utils/calculations';
+import { formatTime, formatDurationReadable, formatInterval, formatRestTime } from '../../utils/dateTime';
+import { Clock, Activity, TrendingUp, Coffee } from 'lucide-react';
 
 const ContractionSummary = () => {
   const { state } = useContractions();
@@ -22,8 +22,8 @@ const ContractionSummary = () => {
 
   return (
     <div className="space-y-6">
-      {/* Stats Overview */}
-      <div className="grid grid-cols-3 gap-4">
+      {/* Stats Overview — 2×2 grid */}
+      <div className="grid grid-cols-2 gap-4">
         <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg text-center">
           <div className="flex justify-center mb-2">
             <Clock className="w-5 h-5 text-primary" />
@@ -45,7 +45,15 @@ const ContractionSummary = () => {
             <TrendingUp className="w-5 h-5 text-primary" />
           </div>
           <div className="text-2xl font-bold">{Math.floor(stats.averageInterval / 60)}m</div>
-          <div className="text-xs text-slate-600 dark:text-slate-400">Avg Interval</div>
+          <div className="text-xs text-slate-600 dark:text-slate-400">Avg Apart</div>
+        </div>
+
+        <div className="bg-slate-100 dark:bg-slate-800 p-4 rounded-lg text-center">
+          <div className="flex justify-center mb-2">
+            <Coffee className="w-5 h-5 text-primary" />
+          </div>
+          <div className="text-2xl font-bold">{Math.floor(stats.averageRestTime / 60)}m</div>
+          <div className="text-xs text-slate-600 dark:text-slate-400">Avg Rest</div>
         </div>
       </div>
 
@@ -78,6 +86,11 @@ const ContractionSummary = () => {
                     {formatInterval(
                       Math.floor((recentThree[index].startTime - recentThree[index + 1].startTime) / 1000)
                     )}
+                    <span className="block">
+                      {formatRestTime(
+                        calculateRestTime(recentThree[index + 1], recentThree[index])
+                      )}
+                    </span>
                   </div>
                 )}
               </div>

--- a/src/components/Timer/ContractionSummary.tsx
+++ b/src/components/Timer/ContractionSummary.tsx
@@ -76,7 +76,7 @@ const ContractionSummary = () => {
                 {index < recentThree.length - 1 && (
                   <div className="text-xs text-slate-600 dark:text-slate-400">
                     {formatInterval(
-                      Math.floor((recentThree[index].startTime - (recentThree[index + 1].endTime || 0)) / 1000)
+                      Math.floor((recentThree[index].startTime - recentThree[index + 1].startTime) / 1000)
                     )}
                   </div>
                 )}

--- a/src/services/storage/localStorage.ts
+++ b/src/services/storage/localStorage.ts
@@ -1,14 +1,11 @@
 import { GoogleSheetsConfig, SyncBackend } from '../../types/sync';
 import { HistoryEntry } from '../../types/history';
 
-export type ChartDisplayMode = 'duration' | 'interval' | 'both';
-
 const KEYS = {
   THEME: 'contraction-tracker-theme',
   GOOGLE_SHEETS_CONFIG: 'contraction-tracker-google-sheets-config',
   LAST_SYNC_TIME: 'contraction-tracker-last-sync',
   INTENSITY_PROMPT_ENABLED: 'contraction-tracker-intensity-prompt-enabled',
-  CHART_DISPLAY_MODE: 'contraction-tracker-chart-display-mode',
   FIREBASE_USER_ID: 'contraction-tracker-firebase-user-id',
   SYNC_BACKEND: 'contraction-tracker-sync-backend',
   HISTORY_ENTRIES: 'contraction-tracker-history-entries',
@@ -72,19 +69,6 @@ export const getIntensityPromptEnabled = (): boolean => {
 
 export const setIntensityPromptEnabled = (enabled: boolean): void => {
   localStorage.setItem(KEYS.INTENSITY_PROMPT_ENABLED, enabled.toString());
-};
-
-// Chart display mode
-export const getChartDisplayMode = (): ChartDisplayMode => {
-  const stored = localStorage.getItem(KEYS.CHART_DISPLAY_MODE);
-  if (stored === 'duration' || stored === 'interval' || stored === 'both') {
-    return stored;
-  }
-  return 'both'; // Default to both charts
-};
-
-export const setChartDisplayMode = (mode: ChartDisplayMode): void => {
-  localStorage.setItem(KEYS.CHART_DISPLAY_MODE, mode);
 };
 
 // Firebase user ID management

--- a/src/types/contraction.ts
+++ b/src/types/contraction.ts
@@ -17,7 +17,8 @@ export interface Contraction {
 export interface ContractionStats {
   total: number;
   averageDuration: number;       // Seconds
-  averageInterval: number;       // Seconds
+  averageInterval: number;       // Seconds (start-to-start)
+  averageRestTime: number;       // Seconds (end-to-start)
   lastContraction?: Contraction;
   recentContractions: Contraction[];
 }

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -11,8 +11,8 @@ export const calculateDuration = (startTime: number, endTime: number): number =>
  * Calculate the interval between two contractions in seconds
  */
 export const calculateInterval = (contraction1: Contraction, contraction2: Contraction): number => {
-  if (!contraction1.endTime || !contraction2.startTime) return 0;
-  return Math.floor((contraction2.startTime - contraction1.endTime) / 1000);
+  const diff = contraction2.startTime - contraction1.startTime;
+  return diff > 0 ? Math.floor(diff / 1000) : 0;
 };
 
 /**

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -8,10 +8,19 @@ export const calculateDuration = (startTime: number, endTime: number): number =>
 };
 
 /**
- * Calculate the interval between two contractions in seconds
+ * Calculate the interval between two contractions in seconds (start-to-start)
  */
 export const calculateInterval = (contraction1: Contraction, contraction2: Contraction): number => {
   const diff = contraction2.startTime - contraction1.startTime;
+  return diff > 0 ? Math.floor(diff / 1000) : 0;
+};
+
+/**
+ * Calculate the rest time between two contractions in seconds (end-to-start)
+ */
+export const calculateRestTime = (older: Contraction, newer: Contraction): number => {
+  if (!older.endTime) return 0;
+  const diff = newer.startTime - older.endTime;
   return diff > 0 ? Math.floor(diff / 1000) : 0;
 };
 
@@ -26,6 +35,7 @@ export const calculateStats = (contractions: Contraction[]): ContractionStats =>
       total: 0,
       averageDuration: 0,
       averageInterval: 0,
+      averageRestTime: 0,
       recentContractions: []
     };
   }
@@ -34,22 +44,31 @@ export const calculateStats = (contractions: Contraction[]): ContractionStats =>
   const totalDuration = completedContractions.reduce((sum, c) => sum + (c.duration || 0), 0);
   const averageDuration = Math.floor(totalDuration / completedContractions.length);
 
-  // Calculate average interval
+  // Calculate average interval (start-to-start) and rest time (end-to-start)
   let totalInterval = 0;
   let intervalCount = 0;
+  let totalRestTime = 0;
+  let restTimeCount = 0;
   for (let i = 0; i < completedContractions.length - 1; i++) {
     const interval = calculateInterval(completedContractions[i + 1], completedContractions[i]);
     if (interval > 0) {
       totalInterval += interval;
       intervalCount++;
     }
+    const restTime = calculateRestTime(completedContractions[i + 1], completedContractions[i]);
+    if (restTime > 0) {
+      totalRestTime += restTime;
+      restTimeCount++;
+    }
   }
   const averageInterval = intervalCount > 0 ? Math.floor(totalInterval / intervalCount) : 0;
+  const averageRestTime = restTimeCount > 0 ? Math.floor(totalRestTime / restTimeCount) : 0;
 
   return {
     total: completedContractions.length,
     averageDuration,
     averageInterval,
+    averageRestTime,
     lastContraction: completedContractions[0],
     recentContractions: completedContractions.slice(0, 10)
   };

--- a/src/utils/dateTime.ts
+++ b/src/utils/dateTime.ts
@@ -71,6 +71,23 @@ export const formatInterval = (seconds: number): string => {
 };
 
 /**
+ * Format rest time in seconds to a readable string (e.g., "5 min rest")
+ */
+export const formatRestTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+
+  if (mins < 1) {
+    return `${seconds}s rest`;
+  }
+
+  if (mins === 1) {
+    return '1 min rest';
+  }
+
+  return `${mins} min rest`;
+};
+
+/**
  * Get relative time string (e.g., "2 minutes ago", "just now")
  */
 export const getRelativeTime = (timestamp: number): string => {


### PR DESCRIPTION
## Summary

- **Fix interval calculation**: intervals now use start-to-start timing (medical standard / 5-1-1 rule). Previous end-to-start calculation made intervals appear ~45-90 seconds shorter than users expected.
- **Add rest time metric**: surfaces the actual break between contractions (end-to-start) alongside the interval, since both are useful
- **Charts redesign**: removes display-mode tabs — all 3 graphs (Duration, Interval, Rest Time) always visible and stacked; each has a subtitle explaining what it shows; default time range changed to All

Closes #2

## Test plan

- [ ] Record contractions ~5 minutes apart — verify summary shows "5 min apart" (was showing ~4 min)
- [ ] Verify Avg Rest is consistently less than Avg Apart by roughly the avg contraction duration
- [ ] Summary list shows both "Xm apart" and "Xm rest" for each recent contraction pair
- [ ] Stats grid shows 4 cards in 2×2 layout: Total, Avg Duration, Avg Apart, Avg Rest
- [ ] Charts page shows all 3 graphs without any tabs; each has a subtitle
- [ ] Default time range is "All" when opening the charts tab
- [ ] Time range buttons filter all 3 charts simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)